### PR TITLE
Allow proxy

### DIFF
--- a/lib/gus_bir1/client.rb
+++ b/lib/gus_bir1/client.rb
@@ -149,7 +149,8 @@ module GusBir1
         element_form_default: :qualified,
         multipart: true,
         log_level: @log_level,
-        log: @logging
+        log: @logging,
+        proxy: ENV['GUS_BIR_PROXY_URL']
       }
       if defined?(@sid) && @sid.nil? == false
         params.merge!({headers: { sid: @sid } })


### PR DESCRIPTION
This change makes gus_bir1 useful on heroku via addon https://elements.heroku.com/addons/fixie (static outbound IP)

Set value of FIXIE_URL as GUS_BIR_PROXY_URL

Of course any other proxy server can be used.