### PR TITLE
Remove polish characters from gemspec

### DIFF
--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -7,7 +7,7 @@ require 'gus_bir1/version'
 Gem::Specification.new do |spec|
   spec.name          = 'gus_bir1'
   spec.version       = GusBir1::VERSION
-  spec.authors       = ['Wacław Łuczak']
+  spec.authors       = ['Waclaw Luczak']
   spec.email         = ['waclaw@luczak.it']
 
   spec.summary       = 'Rails GUS API library based on official REGON SOAP api.'


### PR DESCRIPTION
First of all, thank you for your gem. 
Please consider removing polish characters from gemspec, because I got an error while running fluentd, which was trying to run bundler/setup on its own with ASCII encoding, which led to UndefinedConversion error which I was trying to fix for way too long. 
