### PR TITLE
Fix gem not working after httpi and savon updates

### DIFF
--- a/lib/gus_bir1/client.rb
+++ b/lib/gus_bir1/client.rb
@@ -85,8 +85,8 @@ module GusBir1
 
     def method_missing(method, *args)
       if savon_client.operations.include? method
-        response_hash = call(method, args[0]).hash
-        response_hash.dig(:envelope, :body, "#{method}_response".to_sym, "#{method}_result".to_sym)
+        response_body = call(method, args[0]).body
+        response_body.dig("#{method}_response".to_sym, "#{method}_result".to_sym)
       else
         super
       end


### PR DESCRIPTION
In the recent update of savon gem from 2.12 to 2.14 ( https://github.com/savonrb/savon/blob/master/CHANGELOG.md ) there is a breaking change:

BC BREAKING Fix: https://github.com/savonrb/savon/pull/985 Renamed Savon::Response#hash to Savon::Response#full_hash

This change crashes gus_bir1. The proposed change fixes it.

It is not however researched thoroughly, there might other areas of the gem that are still affected.