### PR TITLE
Add ruby 3.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.3.0
+
+- Removed `ostruct` from codebase. Replaced data structures returned by the library with the `Struct` defined underneath. This might be a breaking change if you used OpenStruct and extended it by adding your own fields in your applications.
+```rb
+SearchResult = Struct.new(:name, :regon, :province, :district, :community, :city, :zip_code, :street, :street_number, :house_number, :street_address, :type, :silos_id, :type_desc, :silos_desc, :report :post_city)
+```

--- a/README.md
+++ b/README.md
@@ -76,47 +76,47 @@ To start querying the GUS database, You can use three methods `GusBir1.find_by`,
 with `regon`
 ```ruby
 response = GusBir1.find_by(regon: '00033150100000')
- => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct GusBir1::Response::SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 response.class
  => Array
 response.first
- => #<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">
+ => #<struct GusBir1::Response::SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">
 ```
 
 with `nip`
 ```ruby
 response = GusBir1.find_by(nip: '8992689516')
- => [#<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct GusBir1::Response::SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
  ```
 
 with `krs`
 ```ruby
 response = GusBir1.find_by(krs: '0000352235')
- => [#<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct GusBir1::Response::SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 ```
 
 with `regons14` (up to 20 regons)
 ```ruby
 response = GusBir1.find_by(regons14: '00033150100000,02121583300000')
- => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct GusBir1::Response::SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct GusBir1::Response::SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
  ```
 
  with `regons9` (up to 20 regons)
  ```ruby
  response = GusBir1.find_by(regons9: '000331501,021215833')
- => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct GusBir1::Response::SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct GusBir1::Response::SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
   ```
 
 with `nips` (up to 20 nips)
 ```ruby
  response = GusBir1.find_by(nips: '8992689516,5261040828')
- => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct GusBir1::Response::SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct GusBir1::Response::SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 ```
 
 with `krss` (up to 20 krss)
 ```ruby
 response = GusBir1.find_by(krss: '0000352235')
- => [#<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct GusBir1::Response::SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 ```
 
 #### get_full_data
@@ -146,7 +146,7 @@ response.first.class
 ## Example
 
 ```ruby
-company = struct SearchResult.new
+company = struct GusBir1::Response::SearchResult.new
 
 gus_response = GusBir1.find_and_get_full_data(nip: 5261040828)
 if gus_response.first
@@ -166,7 +166,7 @@ if gus_response.first
 end
 
 company
- => #<struct SearchResult name="GUS", address="ul. Test-Krucza 208", zip="00-925", city="Warszawa", country="POLSKA", regon="00033150100000", nip="5261040828">
+ => #<struct GusBir1::Response::SearchResult name="GUS", address="ul. Test-Krucza 208", zip="00-925", city="Warszawa", country="POLSKA", regon="00033150100000", nip="5261040828">
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -76,47 +76,47 @@ To start querying the GUS database, You can use three methods `GusBir1.find_by`,
 with `regon`
 ```ruby
 response = GusBir1.find_by(regon: '00033150100000')
- => [#<OpenStruct name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 response.class
  => Array
 response.first
- => #<OpenStruct name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">
+ => #<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">
 ```
 
 with `nip`
 ```ruby
 response = GusBir1.find_by(nip: '8992689516')
- => [#<OpenStruct name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
  ```
 
 with `krs`
 ```ruby
 response = GusBir1.find_by(krs: '0000352235')
- => [#<OpenStruct name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 ```
 
 with `regons14` (up to 20 regons)
 ```ruby
 response = GusBir1.find_by(regons14: '00033150100000,02121583300000')
- => [#<OpenStruct name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<OpenStruct name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
  ```
 
  with `regons9` (up to 20 regons)
  ```ruby
  response = GusBir1.find_by(regons9: '000331501,021215833')
- => [#<OpenStruct name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<OpenStruct name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
   ```
 
 with `nips` (up to 20 nips)
 ```ruby
  response = GusBir1.find_by(nips: '8992689516,5261040828')
- => [#<OpenStruct name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<OpenStruct name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct SearchResult name="GŁÓWNY URZĄD STATYSTYCZNY", regon="00033150100000", province="MAZOWIECKIE", district="m. st. Warszawa", community="Śródmieście", city="Warszawa", zip_code="00-925", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">, #<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 ```
 
 with `krss` (up to 20 krss)
 ```ruby
 response = GusBir1.find_by(krss: '0000352235')
- => [#<OpenStruct name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
+ => [#<struct SearchResult name="\"PSP POLSKA\" SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ", regon="02121583300000", province="DOLNOŚLĄSKIE", district="m. Wrocław", community="Wrocław-Stare Miasto", city="Wrocław", zip_code="53-505", street="ul. Test-Krucza", type="P", silos_id="6", type_desc="Typ jednostki – jednostka prawna", silos_desc="Miejsce prowadzenia działalności jednostki prawnej", report="PublDaneRaportPrawna">]
 ```
 
 #### get_full_data
@@ -146,7 +146,7 @@ response.first.class
 ## Example
 
 ```ruby
-company = OpenStruct.new
+company = struct SearchResult.new
 
 gus_response = GusBir1.find_and_get_full_data(nip: 5261040828)
 if gus_response.first
@@ -166,7 +166,7 @@ if gus_response.first
 end
 
 company
- => #<OpenStruct name="GUS", address="ul. Test-Krucza 208", zip="00-925", city="Warszawa", country="POLSKA", regon="00033150100000", nip="5261040828">
+ => #<struct SearchResult name="GUS", address="ul. Test-Krucza 208", zip="00-925", city="Warszawa", country="POLSKA", regon="00033150100000", nip="5261040828">
 ```
 
 

--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'savon', '~> 2.14'
   spec.add_dependency 'savon-multipart'
+  spec.add_dependency 'ostruct', '~> 0.6'
 end

--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'savon', '~> 2.14'
+  spec.add_dependency 'savon', '~> 2.15'
   spec.add_dependency 'savon-multipart'
   spec.add_dependency 'ostruct', '~> 0.6'
 end

--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'savon', '~> 2.15'
   spec.add_dependency 'savon-multipart'
-  spec.add_dependency 'ostruct', '~> 0.6'
 end

--- a/lib/gus_bir1.rb
+++ b/lib/gus_bir1.rb
@@ -11,7 +11,6 @@ require 'gus_bir1/report/types'
 require 'gus_bir1/report/type_mapper'
 require 'gus_bir1/errors'
 require 'forwardable'
-require 'ostruct'
 
 module GusBir1
   class << self

--- a/lib/gus_bir1/response/search.rb
+++ b/lib/gus_bir1/response/search.rb
@@ -2,6 +2,11 @@
 
 module GusBir1
   module Response
+    SearchResult = Struct.new(:name, :regon, :province, :district, :community,
+                              :city, :zip_code, :street, :street_number,
+                              :house_number, :street_address, :type, :silos_id,
+                              :type_desc, :silos_desc, :report, :post_city)
+
     class Search
       def initialize(body)
         @body = body
@@ -17,25 +22,25 @@ module GusBir1
       private
 
       def parse_dane(hash)
-        search_result                = OpenStruct.new
-        search_result.name           = hash['Nazwa']
-        search_result.regon          = hash['Regon']
-        search_result.province       = hash['Wojewodztwo']
-        search_result.district       = hash['Powiat']
-        search_result.community      = hash['Gmina']
-        search_result.city           = hash['Miejscowosc']
-        search_result.zip_code       = hash['KodPocztowy']
-        search_result.street         = hash['Ulica']
-        search_result.street_number  = hash['NrNieruchomosci']
-        search_result.house_number   = hash['NrLokalu']
-        search_result.street_address = street_address_from(hash)
-        search_result.type           = hash['Typ']
-        search_result.silos_id       = hash['SilosID']
-        search_result.type_desc      = type_info(search_result)
-        search_result.silos_desc     = silos_info(search_result)
-        search_result.report         = report_info(search_result)
-        search_result.post_city      = hash['MiejscowoscPoczty']
-        search_result
+        SearchResult.new.tap do |search_result|
+          search_result.name           = hash['Nazwa']
+          search_result.regon          = hash['Regon']
+          search_result.province       = hash['Wojewodztwo']
+          search_result.district       = hash['Powiat']
+          search_result.community      = hash['Gmina']
+          search_result.city           = hash['Miejscowosc']
+          search_result.zip_code       = hash['KodPocztowy']
+          search_result.street         = hash['Ulica']
+          search_result.street_number  = hash['NrNieruchomosci']
+          search_result.house_number   = hash['NrLokalu']
+          search_result.street_address = street_address_from(hash)
+          search_result.type           = hash['Typ']
+          search_result.silos_id       = hash['SilosID']
+          search_result.type_desc      = type_info(search_result)
+          search_result.silos_desc     = silos_info(search_result)
+          search_result.report         = report_info(search_result)
+          search_result.post_city      = hash['MiejscowoscPoczty']
+        end
       end
 
       def type_info(search_result)

--- a/lib/gus_bir1/version.rb
+++ b/lib/gus_bir1/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GusBir1
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/lib/gus_bir1/version.rb
+++ b/lib/gus_bir1/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GusBir1
-  VERSION = '1.2.2'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
Since `ostruct` is being removed from default gems in Ruby 3.5, this library will fail to run in the next Ruby version.

That's why I've removed OpenStruct from codebase and replaced it with `Struct`. It keeps the functionality (like `#to_s`, `#to_h` and Hash-like extracting values `["key"]`) while it's not going to become deprecated in foreseeable future.