### PR TITLE
Remove multipart option and savon-multipart dependency. Make debug logging optional.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       CI: true
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4', '4.0']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Or install it yourself as:
 # TEST CONF
 GusBir1.production = false
 GusBir1.client_key = 'abcde12345abcde12345'
+
+# Optional, disabled by default. Enable Savon/HTTPI debug logging:
+GusBir1.logging = true
+GusBir1.log_level = :debug
 ```
 
 ### General info

--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'savon', '~> 2.15'
-  spec.add_dependency 'savon-multipart'
+  spec.add_dependency 'savon', '~> 2.17'
 end

--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Rails GUS API library based on official REGON SOAP api.'
   spec.homepage      = 'https://github.com/espago/gus_bir1'
   spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 3.3.0'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -27,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'savon', '~> 2.17'
+  spec.add_dependency 'savon', '~> 2.17.4'
 end

--- a/gus_bir1.gemspec
+++ b/gus_bir1.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Rails GUS API library based on official REGON SOAP api.'
   spec.homepage      = 'https://github.com/espago/gus_bir1'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 3.3.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/lib/gus_bir1/client.rb
+++ b/lib/gus_bir1/client.rb
@@ -15,6 +15,10 @@ module GusBir1
 
     attr_accessor :production, :client_key, :log_level, :logging
 
+    def initialize
+      @logging = false
+    end
+
     def service_status
       v = get_value(Constants::PARAM_PARAM_NAME => Constants::PARAM_SERVICE_STATUS)
       Response::Simple.new(v, Constants::PARAM_SERVICE_STATUS)
@@ -106,7 +110,7 @@ module GusBir1
 
     def call(method, message)
       client = PUBL_OPERATIONS.include?(method) ? savon_client_publ : savon_client
-      client.call(method, message: message, soap_action: client.wsdl.soap_action(method))
+      client.call(method, message: message)
     end
 
     def set_session_id
@@ -143,9 +147,7 @@ module GusBir1
     end
 
     def build_savon_client(publ: false)
-      client = Savon.client(savon_options(publ: publ))
-      client.globals[:endpoint] ||= client.wsdl.endpoint
-      client
+      Savon.client(savon_options(publ: publ))
     end
 
     def savon_options(publ: false)

--- a/lib/gus_bir1/client.rb
+++ b/lib/gus_bir1/client.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
+require 'savon'
+
 module GusBir1
   class Client
     SESSION_TIMEOUT = 3600
+    PUBL_OPERATIONS = %i[
+      wyloguj
+      dane_szukaj_podmioty
+      dane_pobierz_pelny_raport
+      dane_komunikat
+      zaloguj
+    ].freeze
+
     attr_accessor :production, :client_key, :log_level, :logging
 
     def service_status
@@ -25,6 +35,7 @@ module GusBir1
       types = [nip, regon, krs, nips, krss, regons14, regons9].compact
       raise TooMuchTypesSelected if types.size > 1
       raise NoOneTypeSelected if types.empty?
+
       if nip
         search_by Constants::SEARCH_TYPE_NIP, nip
       elsif regon
@@ -73,13 +84,14 @@ module GusBir1
 
     def namespaces(publ: true)
       {
-        'xmlns:ns' =>  publ ? Constants::WSDL_NS_PUBL : Constants::WSDL_NS,
+        'xmlns:ns' => publ ? Constants::WSDL_NS_PUBL : Constants::WSDL_NS,
         'xmlns:dat' => Constants::WSDL_NS_DATA_CONTRACT
       }
     end
 
     def endpoint
       return Constants::WSDL_ADDRESS if @production
+
       Constants::WSDL_ADDRESS_TEST
     end
 
@@ -93,21 +105,13 @@ module GusBir1
     end
 
     def call(method, message)
-      case method
-      when
-          :wyloguj,
-          :dane_szukaj_podmioty,
-          :dane_pobierz_pelny_raport,
-          :dane_komunikat,
-          :zaloguj
-        savon_client_publ.call(method, message: message)
-      else
-        savon_client.call(method, message: message)
-      end
+      client = PUBL_OPERATIONS.include?(method) ? savon_client_publ : savon_client
+      client.call(method, message: message, soap_action: client.wsdl.soap_action(method))
     end
 
     def set_session_id
       return @sid if sid_active
+
       @sid_exp = Time.now + SESSION_TIMEOUT
       @sid = zaloguj(Constants::PARAM_USER_KEY => @client_key)
       clear_savon_clients
@@ -126,15 +130,22 @@ module GusBir1
 
     def logout
       return unless sid_active
+
       wyloguj(Constants::PARAM_SESSION_ID => @sid)
     end
 
     def savon_client_publ
-      @savon_client_publ ||= Savon.client(savon_options(publ: true))
+      @savon_client_publ ||= build_savon_client(publ: true)
     end
 
     def savon_client
-      @savon_client ||= Savon.client(savon_options)
+      @savon_client ||= build_savon_client(publ: false)
+    end
+
+    def build_savon_client(publ: false)
+      client = Savon.client(savon_options(publ: publ))
+      client.globals[:endpoint] ||= client.wsdl.endpoint
+      client
     end
 
     def savon_options(publ: false)
@@ -146,14 +157,11 @@ module GusBir1
         soap_version: 2,
         namespace_identifier: :ns,
         element_form_default: :qualified,
-        multipart: true,
         log_level: @log_level,
         log: @logging,
         proxy: ENV['GUS_BIR_PROXY_URL']
       }
-      if defined?(@sid) && @sid.nil? == false
-        params.merge!({headers: { sid: @sid } })
-      end
+      params.merge!({ headers: { sid: @sid } }) if defined?(@sid) && @sid.nil? == false
       params
     end
 
@@ -161,11 +169,5 @@ module GusBir1
       @savon_client = nil
       @savon_client_publ = nil
     end
-
-    def savon_api_client
-      @savon_api_client ||= GusBir1::SavonApiClient.new
-    end
   end
 end
-require 'savon'
-require 'savon-multipart'

--- a/lib/gus_bir1/version.rb
+++ b/lib/gus_bir1/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GusBir1
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/test/gus_bir1_test.rb
+++ b/test/gus_bir1_test.rb
@@ -27,7 +27,7 @@ class GusBir1Test < Minitest::Test
       report: 'PublDaneRaportPrawna',
       street_number: '208',
       house_number: nil,
-      street_address: "ul. Test-Krucza 208",
+      street_address: 'ul. Test-Krucza 208',
       post_city: 'Warszawa'
     }
 
@@ -47,7 +47,7 @@ class GusBir1Test < Minitest::Test
       report: 'PublDaneRaportPrawna',
       street_number: '15',
       house_number: nil,
-      street_address: "ul. Test-Krucza 15",
+      street_address: 'ul. Test-Krucza 15',
       post_city: 'Wrocław'
     }
   end


### PR DESCRIPTION
Since 2.17 version Savon shows this warning:

```sh
warning: The global :multipart option has been a no-op since v2.13.0. Savon detects whether the response is multipart by checking if the response Content-Type header contains 'multipart'. You can removethis option from your code to make this warning disappear.
```

As such, I removed multipart option from client, removed savon-mutlipart dependency.

Also, I've introduced two additional config options for this gem: `GusBir1.logging` (default: false) and `GusBir1.log_level` (default: nil).

You can change them when initializing gem:
```rb
GusBir1.logging  = true
GusBir1.log_level = :debug
```

I believe this should be changed because debug log spam shouldn't be default behaviour.